### PR TITLE
Fix example program and other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ int main() {
 
   // write that same content to another file
   wave::File write_file;
-  write_file.Open("/home/gvne/test_write.wav", wave::kOut);
+  err = write_file.Open("/home/gvne/test_write.wav", wave::kOut);
   if (err) {
     std::cout << "Something went wrong in out open" << std::endl;
     return 3;

--- a/README.md
+++ b/README.md
@@ -22,25 +22,33 @@ see [this](http://stackoverflow.com/questions/13660777/c-reading-the-data-part-o
 int main() {
   // read file's content
   wave::File read_file;
-  read_file.Open("/home/gvne/test.wav");
-  std::error_code err;
-  auto content = read_file.Read(err);
+  wave::Error err = read_file.Open("/home/gvne/test.wav", wave::kIn);
   if (err) {
-    std::cout << "Something went wrong" << std::endl;
-    return 0;
+    std::cout << "Something went wrong in in open" << std::endl;
+    return 1;
+  }
+  std::vector<float> content;
+  err = read_file.Read(&content);
+  if (err) {
+    std::cout << "Something went wrong in read" << std::endl;
+    return 2;
   }
 
   // write that same content to another file
   wave::File write_file;
-  write_file.Open("/home/gvne/test_write.wav");
+  write_file.Open("/home/gvne/test_write.wav", wave::kOut);
+  if (err) {
+    std::cout << "Something went wrong in out open" << std::endl;
+    return 3;
+  }
   write_file.set_sample_rate(read_file.sample_rate());
   write_file.set_bits_per_sample(read_file.bits_per_sample());
   write_file.set_channel_number(read_file.channel_number());
 
-  write_file.Write(content, err);
+  err = write_file.Write(content);
   if (err) {
-    std::cout << "Something went wrong" << std::endl;
-    return 0;
+    std::cout << "Something went wrong in write" << std::endl;
+    return 4;
   }
 
   return 0;

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 ## Libwave
-A simple cross platform C++ interface for reading WAVE files.
+A simple cross platform C++ interface for reading and writing WAVE files.
 
 The WAVE file structure taken for reference is:
 

--- a/src/wave/error.h
+++ b/src/wave/error.h
@@ -4,7 +4,7 @@
 namespace wave {
 
 enum Error {
-  kNoError,
+  kNoError = 0,
   kFailedToOpen,
   kNotOpen,
   kInvalidFormat,

--- a/src/wave/file.h
+++ b/src/wave/file.h
@@ -30,20 +30,20 @@ class File {
 
   /**
    * @brief Read the entire content of file.
-   * @note: File has to be opened in kOut mode of kNotOpen will be returned
+   * @note: File has to be opened in kOut mode or kNotOpen will be returned
    */
   Error Read(std::vector<float>* output);
 
   /**
    * @brief Read the given number of frames from file.
-   * @note: File has to be opened in kOut mode of kNotOpen will be returned.
+   * @note: File has to be opened in kOut mode or kNotOpen will be returned.
    * If file is too small, kInvalidFormat is returned
    */
   Error Read(uint64_t frame_number, std::vector<float>* output);
 
   /**
    * @brief Read and decrypt the entire content of file.
-   * @note: File has to be opened in kOut mode of kNotOpen will be returned
+   * @note: File has to be opened in kOut mode or kNotOpen will be returned
    */
   Error Read(void (*decrypt)(char* data, size_t size),
              std::vector<float>* output);
@@ -52,13 +52,13 @@ class File {
 
   /**
    * @brief Write the given data
-   * @note: File has to be opened in kIn mode of kNotOpen will be returned.
+   * @note: File has to be opened in kIn mode or kNotOpen will be returned.
    */
   Error Write(const std::vector<float>& data);
 
   /**
    * @brief Write and Encrypt using encryption function
-   * @note: File has to be opened in kIn mode of kNotOpen will be returned.
+   * @note: File has to be opened in kIn mode or kNotOpen will be returned.
    */
   Error Write(const std::vector<float>& data,
               void (*encrypt)(char* data, size_t size));


### PR DESCRIPTION
The example in the README.md seemed to be using an older API.  This updates it so that it works with the current library source.

Also made the fact that no-error is 0 in return codes explicit in the header file so that it will be that way in all compilations.

Also added the fact that the library can write WAV files to the README.md.

Also fixed some spelling in the header file comments.