### PR TITLE
Move assignment operator must return *this

### DIFF
--- a/src/wave/file.cc
+++ b/src/wave/file.cc
@@ -372,6 +372,7 @@ File::File(File&& other) : impl_(nullptr) {
 
 File& File::operator=(File&& other) {
   impl_.reset(other.impl_.release());
+  return *this;
 }
 #endif // __cplusplus > 201103L
 


### PR DESCRIPTION
Thank you for developing this useful library!

I got the following warning from GCC 9.3.0.

```
/.../wave/src/wave/file.cc: In member function ‘wave::File& wave::File::operator=(wave::File&&)’:
/.../wave/src/wave/file.cc:375:1: warning: no return statement in function returning non-void [-Wreturn-type]
  374 |   impl_.reset(other.impl_.release());
  +++ |+  return *this;
  375 | }
      | ^
```

The move assignment operator `File::operator=(File&&)` should return the reference to the `File` instance.

```diff
  File& File::operator=(File&& other) {
    impl_.reset(other.impl_.release());
+   return *this;
  }
```