### PR TITLE
Fix CMakeLists.txt for library use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(wave_enable_tests)
   endforeach()
 endif ()
 
-set(src "${CMAKE_SOURCE_DIR}/src")
+set(src "${PROJECT_SOURCE_DIR}/src")
 include_directories(${src})
 
 add_subdirectory("./src")

--- a/src/wave/CMakeLists.txt
+++ b/src/wave/CMakeLists.txt
@@ -18,6 +18,12 @@ add_library(wave
   ${src}/wave/file.cc
 )
 
+# include path
+target_include_directories(wave
+  INTERFACE
+    ${src}
+)
+
 # install rules
 install(TARGETS wave
   RUNTIME DESTINATION bin


### PR DESCRIPTION
I have fixed `CMakeLists.txt` for linking the library with CMake without installation with `make install`.

Now you can link the library by using `add_subdirectory` from `CMakeLists.txt` in another project like:

```cmake
option(wave_enable_tests "" OFF)
add_subdirectory(third_party/wave) # <= path to this wave repository
target_link_libraries(your_project wave)
```

Changes:
- Using `${PROJECT_SOURCE_DIR}` instead of `${CMAKE_SOURCE_DIR}`
    - Since `${CMAKE_SOURCE_DIR}` is the path of the root project, it should not be used in libraries.
- Added include path to the library target