### PR TITLE
Remove emscripten warning on int to float casting.

### DIFF
--- a/src/wave/file.cc
+++ b/src/wave/file.cc
@@ -280,7 +280,7 @@ Error File::Read(uint64_t frame_number, void (*decrypt)(char*, size_t),
       impl_->istream.read(reinterpret_cast<char*>(&value), sizeof(value));
       decrypt(reinterpret_cast<char*>(&value), sizeof(value) / sizeof(char));
       (*output)[sample_idx] =
-          static_cast<float>(value) / std::numeric_limits<int32_t>::max();
+          static_cast<float>(value) / static_cast<float>(std::numeric_limits<int32_t>::max());
     } else {
       return kInvalidFormat;
     }
@@ -337,7 +337,7 @@ Error File::Write(const std::vector<float>& data,
     } else if (bits_per_sample == 32) {
       // 32bits
       int32_t value =
-          static_cast<int32_t>(sample * std::numeric_limits<int32_t>::max());
+          static_cast<int32_t>(sample * static_cast<float>(std::numeric_limits<int32_t>::max()));
       encrypt(reinterpret_cast<char*>(&value), sizeof(value) / sizeof(char));
       impl_->ostream.write(reinterpret_cast<char*>(&value), sizeof(value));
     } else {


### PR DESCRIPTION
Thanks for this wonderful library! It was been a great experience using wave, which has been working flawlessly also for webassembly. This PR is just for removing some complier warnings.

Currently, there are two warnings such as below, which are the compiler whining about implicit conversion. This PR removes them.

wave/src/wave/file.cc:340:41: warning: implicit conversion from 'std::numeric_limits<int>::type' (aka 'int') to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
          static_cast<int32_t>(sample * std::numeric_limits<int32_t>::max());